### PR TITLE
Update linkedin-oauth2.gemspec

### DIFF
--- a/linkedin-oauth2.gemspec
+++ b/linkedin-oauth2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  "~> 3.2"
-  gem.add_dependency "faraday", "~> 1.0"
+  gem.add_dependency "faraday", "~> 2.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Updating faraday to 2.0 as part of SOC2 compliance